### PR TITLE
Add 'Instant BIN confirm' as a Setting (related to #111)

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -21,6 +21,9 @@ import {
   FutbinSettings,
 } from './futbin';
 
+import {
+  InstantBinConfirmSettings,
+} from './instant-bin-confirm';
 /*
 import {
   ClubInfoSettings,
@@ -61,6 +64,7 @@ services.Authentication._oAuthentication.observe(
     // settings.registerEntry(new ListSizeSettings());
 
     settings.registerEntry(new FutbinSettings());
+    settings.registerEntry(new InstantBinConfirmSettings());
     // settings.registerEntry(new ClubInfoSettings());
 
     initSettingsScreen(settings);

--- a/app/instant-bin-confirm/index.js
+++ b/app/instant-bin-confirm/index.js
@@ -1,0 +1,8 @@
+import { InstantBinConfirmSettings } from './settings-entry';
+import { InstantBinConfirm } from './instant-bin-confirm';
+
+export {
+  InstantBinConfirmSettings,
+};
+
+new InstantBinConfirm(); // eslint-disable-line no-new

--- a/app/instant-bin-confirm/instant-bin-confirm.js
+++ b/app/instant-bin-confirm/instant-bin-confirm.js
@@ -1,0 +1,50 @@
+/* global
+$
+document
+window
+gPopupClickShield
+*/
+
+import { BaseScript } from '../core';
+import { InstantBinConfirmSettings } from './settings-entry';
+
+export class InstantBinConfirm extends BaseScript {
+  constructor() {
+    super(InstantBinConfirmSettings.id);
+  }
+
+  activate(state) {
+    function mutationHandler(mutationRecords) {
+      mutationRecords.forEach((mutation) => {
+        if ($(mutation.addedNodes).hasClass('Dialog')) {
+          const t = gPopupClickShield._activePopup._title;
+          if (t === 'popup.buyNowConfirmationTitle') {
+            setTimeout(() => {
+              gPopupClickShield._activePopup._eOptionSelected(2);
+            }, 13);
+          }
+        }
+      });
+    }
+
+    super.activate(state);
+    const MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
+    const obsConfig = {
+      childList: true,
+      characterData: true,
+      attributes: false,
+      subtree: true,
+    };
+    this.observer = new MutationObserver(mutationHandler);
+    this.observer.observe(document, obsConfig);
+  }
+
+  onScreenRequest(screenId) {
+    super.onScreenRequest(screenId);
+  }
+
+  deactivate(state) {
+    super.deactivate(state);
+    this.observer.disconnect();
+  }
+}

--- a/app/instant-bin-confirm/settings-entry.js
+++ b/app/instant-bin-confirm/settings-entry.js
@@ -1,0 +1,8 @@
+import { SettingsEntry } from '../core';
+
+export class InstantBinConfirmSettings extends SettingsEntry {
+  static id = 'instant-bin-confirm';
+  constructor() {
+    super('instant-bin-confirm', 'Instantly confirm Buy It Now dialog');
+  }
+}


### PR DESCRIPTION
Per [this comment in #111](https://github.com/Mardaneus86/futwebapp-tampermonkey/issues/111#issuecomment-425752196) this PR supplies the "Instant BIN Confirmation" functionality as a Setting within the app's infrastructure.

There is one difference from the implementation in 987c23, which is a 13ms delay before confirming the dialog. I used it this way last year as it felt right to have a small delay here rather than it truly being "instantaneous."