### PR TITLE
feat: show trade pile values

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -16,15 +16,12 @@ import {
   CardInfoSettings,
   ListSizeSettings,
   MinBinSettings,
+  TransferTotalsSettings,
 } from './transferlist';
 
-import {
-  FutbinSettings,
-} from './futbin';
+import { FutbinSettings } from './futbin';
 
-import {
-  InstantBinConfirmSettings,
-} from './instant-bin-confirm';
+import { InstantBinConfirmSettings } from './instant-bin-confirm';
 /*
 import {
   ClubInfoSettings,
@@ -50,32 +47,32 @@ FUIViewController.prototype.didPresent = (t) => {
   }
 };
 
-services.Authentication._oAuthentication.observe(
-  this,
-  () => {
-    // reset the logs at startup
-    new Logger().reset();
+services.Authentication._oAuthentication.observe(this, () => {
+  // reset the logs at startup
+  new Logger().reset();
 
-    // force full web app layout in any case
-    $('body').removeClass('phone').addClass('landscape');
+  // force full web app layout in any case
+  $('body')
+    .removeClass('phone')
+    .addClass('landscape');
 
-    Queue.getInstance().start();
+  Queue.getInstance().start();
 
-    // get rid of pinEvents when switching tabs
-    document.removeEventListener('visibilitychange', onVisibilityChanged);
+  // get rid of pinEvents when switching tabs
+  document.removeEventListener('visibilitychange', onVisibilityChanged);
 
-    const settings = Settings.getInstance();
-    settings.registerEntry(new RefreshListSettings());
-    // settings.registerEntry(new RemoveSoldAuctionsSettings());
-    // settings.registerEntry(new RelistAuctionsSettings());
-    settings.registerEntry(new MinBinSettings());
-    settings.registerEntry(new CardInfoSettings());
-    settings.registerEntry(new ListSizeSettings());
+  const settings = Settings.getInstance();
+  settings.registerEntry(new RefreshListSettings());
+  // settings.registerEntry(new RemoveSoldAuctionsSettings());
+  // settings.registerEntry(new RelistAuctionsSettings());
+  settings.registerEntry(new MinBinSettings());
+  settings.registerEntry(new CardInfoSettings());
+  settings.registerEntry(new ListSizeSettings());
+  settings.registerEntry(new TransferTotalsSettings());
 
-    settings.registerEntry(new FutbinSettings());
-    settings.registerEntry(new InstantBinConfirmSettings());
-    // settings.registerEntry(new ClubInfoSettings());
+  settings.registerEntry(new FutbinSettings());
+  settings.registerEntry(new InstantBinConfirmSettings());
+  // settings.registerEntry(new ClubInfoSettings());
 
-    initSettingsScreen(settings);
-  },
-);
+  initSettingsScreen(settings);
+});

--- a/app/index.js
+++ b/app/index.js
@@ -19,9 +19,13 @@ import {
   TransferTotalsSettings,
 } from './transferlist';
 
-import { FutbinSettings } from './futbin';
+import {
+  FutbinSettings,
+} from './futbin';
 
-import { InstantBinConfirmSettings } from './instant-bin-confirm';
+import {
+  InstantBinConfirmSettings,
+} from './instant-bin-confirm';
 /*
 import {
   ClubInfoSettings,
@@ -47,32 +51,33 @@ FUIViewController.prototype.didPresent = (t) => {
   }
 };
 
-services.Authentication._oAuthentication.observe(this, () => {
-  // reset the logs at startup
-  new Logger().reset();
+services.Authentication._oAuthentication.observe(
+  this,
+  () => {
+    // reset the logs at startup
+    new Logger().reset();
 
-  // force full web app layout in any case
-  $('body')
-    .removeClass('phone')
-    .addClass('landscape');
+    // force full web app layout in any case
+    $('body').removeClass('phone').addClass('landscape');
 
-  Queue.getInstance().start();
+    Queue.getInstance().start();
 
-  // get rid of pinEvents when switching tabs
-  document.removeEventListener('visibilitychange', onVisibilityChanged);
+    // get rid of pinEvents when switching tabs
+    document.removeEventListener('visibilitychange', onVisibilityChanged);
 
-  const settings = Settings.getInstance();
-  settings.registerEntry(new RefreshListSettings());
-  // settings.registerEntry(new RemoveSoldAuctionsSettings());
-  // settings.registerEntry(new RelistAuctionsSettings());
-  settings.registerEntry(new MinBinSettings());
-  settings.registerEntry(new CardInfoSettings());
-  settings.registerEntry(new ListSizeSettings());
-  settings.registerEntry(new TransferTotalsSettings());
+    const settings = Settings.getInstance();
+    settings.registerEntry(new RefreshListSettings());
+    // settings.registerEntry(new RemoveSoldAuctionsSettings());
+    // settings.registerEntry(new RelistAuctionsSettings());
+    settings.registerEntry(new MinBinSettings());
+    settings.registerEntry(new CardInfoSettings());
+    settings.registerEntry(new ListSizeSettings());
+    settings.registerEntry(new TransferTotalsSettings());
 
-  settings.registerEntry(new FutbinSettings());
-  settings.registerEntry(new InstantBinConfirmSettings());
-  // settings.registerEntry(new ClubInfoSettings());
+    settings.registerEntry(new FutbinSettings());
+    settings.registerEntry(new InstantBinConfirmSettings());
+    // settings.registerEntry(new ClubInfoSettings());
 
-  initSettingsScreen(settings);
-});
+    initSettingsScreen(settings);
+  },
+);

--- a/app/transferlist/index.js
+++ b/app/transferlist/index.js
@@ -4,6 +4,7 @@ import { MinBinSettings } from './min-bin';
 import { RelistAuctionsSettings } from './relist-expired';
 import { CardInfoSettings } from './card-info';
 import { ListSizeSettings } from './list-size';
+import { TransferTotalsSettings } from './transer-totals';
 
 export {
   CardInfoSettings,
@@ -12,4 +13,5 @@ export {
   RemoveSoldAuctionsSettings,
   MinBinSettings,
   ListSizeSettings,
+  TransferTotalsSettings,
 };

--- a/app/transferlist/style/transfer-totals.scss
+++ b/app/transferlist/style/transfer-totals.scss
@@ -1,0 +1,48 @@
+.transfer-totals {
+    background-color: #183f94;
+    color: #fff;
+    .auction {
+        float: right;
+        margin: 1em 3em 1em 0;
+        text-align: right;
+        width: 45%;
+        .auctionStartPrice {
+            display: none;
+            @media (min-width: 1281px) {
+                display: block;
+            }
+        }
+        .auctionValue {
+            float: left;
+            padding-right: 1%;
+            width: 24%;
+        }
+        .label {
+            color: #b5b7bb;
+            display: block;
+            font-size: .75rem;
+            text-transform: uppercase;
+        }
+        .value {
+            font-size: 1.125em;
+            font-weight: 400;
+            font-family: UltimateTeamCondensed,sans-serif;
+            display: block;
+        }
+        @media (max-width: 1130px) {
+            align-items: flex-start;
+            box-sizing: border-box;
+            display: flex;
+            float: none;
+            margin: 0;
+            padding: 0.5em 1.2rem 0.5em 113px;
+            text-align: left;
+            width: 100%;
+        }
+    }
+    &:after {
+        content: '';
+        display: table;
+        width: 100%;
+    }
+}

--- a/app/transferlist/transer-totals.js
+++ b/app/transferlist/transer-totals.js
@@ -10,7 +10,7 @@ export class TransferTotalsSettings extends SettingsEntry {
   constructor() {
     super('transfer-totals', 'Transfer list totals', null);
 
-    this.addSetting('Show transfer lost totals', 'show-transfer-totals', 'true');
+    this.addSetting('Show transfer list totals', 'show-transfer-totals', 'true');
   }
 }
 

--- a/app/transferlist/transer-totals.js
+++ b/app/transferlist/transer-totals.js
@@ -1,0 +1,150 @@
+/* globals
+window $ document */
+
+import { BaseScript, SettingsEntry } from '../core';
+
+import './style/transfer-totals.scss';
+
+export class TransferTotalsSettings extends SettingsEntry {
+  static id = 'transfer-totals';
+  constructor() {
+    super('transfer-totals', 'Transfer list totals', null);
+
+    this.addSetting('Show transfer lost totals', 'show-transfer-totals', 'true');
+  }
+}
+
+class TransferTotals extends BaseScript {
+  constructor() {
+    super(TransferTotalsSettings.id);
+
+    const MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
+    this._observer = new MutationObserver(this._mutationHandler.bind(this));
+  }
+
+  activate(state) {
+    super.activate(state);
+
+    const obsConfig = {
+      childList: true,
+      characterData: true,
+      attributes: false,
+      subtree: true,
+    };
+
+    setTimeout(() => {
+      this._observer.observe($(document)[0], obsConfig);
+    }, 0);
+  }
+
+  deactivate(state) {
+    super.deactivate(state);
+    this._observer.disconnect();
+  }
+
+  _mutationHandler(mutationRecords) {
+    const settings = this.getSettings();
+    mutationRecords.forEach((mutation) => {
+      if (
+        $(mutation.target).find('.listFUTItem').length > 0 ||
+        $(mutation.target).find('.futbin').length > 0
+      ) {
+        const controller = getAppMain()
+          .getRootViewController()
+          .getPresentedViewController()
+          .getCurrentViewController()
+          .getCurrentController();
+        if (!controller || !controller._listController) {
+          return;
+        }
+
+        if (window.currentPage !== 'UTTransferListSplitViewController') {
+          return;
+        }
+
+        if (!settings.isActive || settings['show-transfer-totals'] !== 'true') {
+          return;
+        }
+
+        const lists = $('.list-view .itemList');
+
+        lists.each((index, list) => {
+          const totals = {
+            futbin: 0,
+            bid: 0,
+            bin: 0,
+          };
+          const listEl = $(list);
+
+          if (!listEl.find('.listFUTItem').length) {
+            return;
+          }
+
+          listEl.find('.listFUTItem').each((rowIndex, row) => {
+            const rowEl = $(row);
+            const hasFutbin = rowEl.find('.auctionValue.futbin').length > 0;
+            const futbinValue = hasFutbin
+              ? parseInt(
+                rowEl
+                  .find('.auctionValue.futbin .coins.value')
+                  .text()
+                  .replace(/[,.]/g, ''),
+                10,
+              )
+              : 0;
+            const bidValue = parseInt(
+              rowEl
+                .find(`.auctionValue:eq(${hasFutbin ? 2 : 1}) .coins.value`)
+                .text()
+                .replace(/[,.]/g, ''),
+              10,
+            );
+            const binValue = parseInt(
+              rowEl
+                .find(`.auctionValue:eq(${hasFutbin ? 3 : 2}) .coins.value`)
+                .text()
+                .replace(/[,.]/g, ''),
+              10,
+            );
+            totals.futbin += futbinValue;
+            totals.bid += bidValue;
+            totals.bin += binValue;
+          });
+
+          const totalsItem = listEl.prev('.transfer-totals');
+
+          if (!totalsItem.length) {
+            $(`<div class="transfer-totals">
+            <div class="auction">
+              <div class="auctionValue futbin">
+                <span class="label">Futbin BIN</span>
+                <span class="coins value total-futbin">0</span>
+              </div>
+              <div class="auctionStartPrice auctionValue">&nbsp;</div>
+              <div class="auctionValue">
+                <span class="label">Bid Total</span>
+                <span class="coins value total-bid">0</span>
+              </div>
+              <div class="auctionValue">
+                <span class="label">BIN Total</span>
+                <span class="coins value total-bin">0</span>
+              </div>
+            </div>
+          </div>`).insertBefore(listEl);
+          }
+
+          if (totals.futbin > 0) {
+            totalsItem.find('.total-futbin').text(totals.futbin);
+            totalsItem.find('.futbin').show();
+          } else {
+            totalsItem.find('.futbin').hide();
+          }
+          totalsItem.find('.total-bin').text(totals.bin);
+          totalsItem.find('.total-bid').text(totals.bid);
+        });
+      }
+    });
+  }
+}
+
+new TransferTotals(); // eslint-disable-line no-new


### PR DESCRIPTION
This PR implements a new setting for trade pile totals.
If activated, it renders a header row on top of each list in the trade pile area (see screenshot).
It sums up all values (except start price).
Styles have been adopted by the web app.

<img width="1440" alt="49-trade-pile-totals" src="https://user-images.githubusercontent.com/1336590/46910318-eca7a100-cf42-11e8-8cf2-0272b6669409.png">
