### PR TITLE
feat: configure input types for settings and render accordingly

### DIFF
--- a/app/core/settings-entry.js
+++ b/app/core/settings-entry.js
@@ -18,7 +18,7 @@ export class SettingsEntry {
     Database.setJson(`settings:${this.id}`, settings);
   }
 
-  addSetting(label, key, defaultValue, cb) {
+  addSetting(label, key, defaultValue, type, cb) {
     const settings = Database.getJson(`settings:${this.id}`, {});
 
     settings[key] = key in settings ? settings[key] : defaultValue;
@@ -27,13 +27,14 @@ export class SettingsEntry {
     this.settings.push({
       label,
       key,
+      type,
       value: key in settings ? settings[key] : defaultValue,
       callback: cb,
       subsettings: [],
     });
   }
 
-  addSettingUnder(underKey, label, key, defaultValue, cb) {
+  addSettingUnder(underKey, label, key, defaultValue, type, cb) {
     const settings = Database.getJson(`settings:${this.id}`, {});
     settings[key] = key in settings ? settings[key] : defaultValue;
     Database.setJson(`settings:${this.id}`, settings);
@@ -42,6 +43,7 @@ export class SettingsEntry {
     setting.subsettings.push({
       label,
       key,
+      type,
       value: key in settings ? settings[key] : defaultValue,
       callback: cb,
     });

--- a/app/futbin/settings-entry.js
+++ b/app/futbin/settings-entry.js
@@ -5,7 +5,7 @@ export class FutbinSettings extends SettingsEntry {
   constructor() {
     super('futbin', 'FutBIN integration');
 
-    this.addSetting('Show link to player page', 'show-link-to-player', 'false');
-    this.addSetting('Mark bargains', 'show-bargains', 'false');
+    this.addSetting('Show link to player page', 'show-link-to-player', false, 'checkbox');
+    this.addSetting('Mark bargains', 'show-bargains', false, 'checkbox');
   }
 }

--- a/app/settings/index.js
+++ b/app/settings/index.js
@@ -20,33 +20,47 @@ const handleFieldChange = (entry, setting, e) => {
   }
 };
 
+const renderSettingsEntry = (setting, entry) => {
+  const inputId = `${entry.id}:${setting.key}`;
+  return `<div class="setting">
+    <label for="${inputId}">${setting.label}</label>
+    <input
+      type="${setting.type}"
+      id="${inputId}"
+      data-feature-setting-id="${entry.id}:${setting.key}"
+      value="${setting.value}"
+      ${setting.type === 'checkbox' && setting.value.toString() === 'true' ? 'checked' : ''}
+    />
+  </div>`;
+};
+
 export default (settings) => {
   const html = settingsPage;
 
   $('body').prepend(html);
 
   const settingsPanel = $('.futsettings #settingspanel');
+
   for (const entry of settings.getEntries()) {
     const checked = entry.isActive ? 'checked="checked"' : '';
-    settingsPanel.append(`<h3><input type="checkbox" id="${entry.id}" data-feature-id="${entry.id}" ${checked}></input><label for="${entry.id}">${entry.name}</label></h3>`);
+    settingsPanel.append(`<h3>
+      <input type="checkbox" id="${entry.id}" data-feature-id="${entry.id}" ${checked} />
+      <label for="${entry.id}">${entry.name}</label>
+    </h3>`);
     let settingsFields = '';
     if (entry.settings && entry.settings.length > 0) {
       for (const setting of entry.settings) {
         if (setting.subsettings.length > 0) {
-          const subChecked = setting.value ? 'checked="checked"' : '';
-          settingsFields += `<input type="checkbox" id="${entry.id}:${setting.key}" data-feature-setting-id="${entry.id}:${setting.key}" ${subChecked}></input>
-            <label for="${entry.id}:${setting.key}">${setting.label}</label>`;
+          settingsFields += renderSettingsEntry(setting, entry);
 
           const settingActive = setting.value ? 'block' : 'none';
           settingsFields += `<div data-parent-feature-setting-id="${entry.id}:${setting.key}" style="display: ${settingActive}">`;
           for (const subsetting of setting.subsettings) {
-            settingsFields += `<div class="setting"><label for="${entry.id}:${subsetting.key}">${subsetting.label}</label>
-              <input type="text" id="${entry.id}:${subsetting.key}" data-feature-setting-id="${entry.id}:${subsetting.key}" value="${subsetting.value}"></input></div>`;
+            settingsFields += renderSettingsEntry(subsetting, entry);
           }
           settingsFields += '</div>';
         } else {
-          settingsFields += `<div class="setting"><label for="${entry.id}:${setting.key}">${setting.label}</label>
-            <input type="text" id="${entry.id}:${setting.key}" data-feature-setting-id="${entry.id}:${setting.key}" value="${setting.value}"></input></div>`;
+          settingsFields += renderSettingsEntry(setting, entry);
         }
       }
       const featureActive = entry.isActive ? 'block' : 'none';

--- a/app/settings/index.scss
+++ b/app/settings/index.scss
@@ -55,6 +55,7 @@
 
       padding: 8px;
 
+      input[type=number],
       input[type=text] {
         width: 100%;
         height: 2.5em;

--- a/app/transferlist/card-info.js
+++ b/app/transferlist/card-info.js
@@ -10,8 +10,8 @@ export class CardInfoSettings extends SettingsEntry {
   constructor() {
     super('card-info', 'Extra card information', null);
 
-    this.addSetting('Show contracts', 'show-contracts', 'true');
-    this.addSetting('Show fitness', 'show-fitness', 'true');
+    this.addSetting('Show contracts', 'show-contracts', true, 'checkbox');
+    this.addSetting('Show fitness', 'show-fitness', true, 'checkbox');
   }
 }
 

--- a/app/transferlist/list-size.js
+++ b/app/transferlist/list-size.js
@@ -8,8 +8,8 @@ export class ListSizeSettings extends SettingsEntry {
   static id = 'list-size';
   constructor() {
     super('list-size', 'Increase transfer list size', null);
-    this.addSetting('Items per page on transfer market (max 30)', 'items-per-page-transfermarket', 30);
-    this.addSetting('Items per page on club (max 90)', 'items-per-page-club', 90);
+    this.addSetting('Items per page on transfer market (max 30)', 'items-per-page-transfermarket', 30, 'number');
+    this.addSetting('Items per page on club (max 90)', 'items-per-page-club', 90, 'number');
   }
 }
 

--- a/app/transferlist/min-bin.js
+++ b/app/transferlist/min-bin.js
@@ -9,10 +9,10 @@ export class MinBinSettings extends SettingsEntry {
   constructor() {
     super('min-bin', 'Search minimum BIN');
 
-    this.addSetting('Amount of lowest BINs to determine minimum on', 'mean-count', '3');
-    this.addSetting('Adjust quicklist panel price automatically based on minimum BIN', 'adjust-list-price', true);
-    this.addSettingUnder('adjust-list-price', 'Start price percentage (0 to 100%)', 'start-price-percentage', '90');
-    this.addSettingUnder('adjust-list-price', 'Buy now price percentage (0 to 100%)', 'buy-now-price-percentage', '110');
+    this.addSetting('Amount of lowest BINs to determine minimum on', 'mean-count', 3, 'number');
+    this.addSetting('Adjust quicklist panel price automatically based on minimum BIN', 'adjust-list-price', true, 'checkbox');
+    this.addSettingUnder('adjust-list-price', 'Start price percentage (0 to 100%)', 'start-price-percentage', 90, 'number');
+    this.addSettingUnder('adjust-list-price', 'Buy now price percentage (0 to 100%)', 'buy-now-price-percentage', 110, 'number');
   }
 }
 

--- a/app/transferlist/relist-expired.js
+++ b/app/transferlist/relist-expired.js
@@ -10,10 +10,10 @@ export class RelistAuctionsSettings extends SettingsEntry {
   static id = 'relist-auctions';
   constructor() {
     super('relist-auctions', 'Relist expired auctions automatically', null);
-    this.addSetting('Interval in seconds', 'interval', 300);
-    this.addSetting('Relist at BIN price', 'relist-bin-price', true);
-    this.addSettingUnder('relist-bin-price', 'Start price percentage (0 to 100%)', 'relist-bin-price-start', 90);
-    this.addSettingUnder('relist-bin-price', 'Buy now price percentage (0 to 100%)', 'relist-bin-price-buynow', 110);
+    this.addSetting('Interval in seconds', 'interval', 300, 'number');
+    this.addSetting('Relist at BIN price', 'relist-bin-price', true, 'checkbox');
+    this.addSettingUnder('relist-bin-price', 'Start price percentage (0 to 100%)', 'relist-bin-price-start', 90, 'number');
+    this.addSettingUnder('relist-bin-price', 'Buy now price percentage (0 to 100%)', 'relist-bin-price-buynow', 110, 'number');
   }
 }
 

--- a/app/transferlist/remove-sold.js
+++ b/app/transferlist/remove-sold.js
@@ -10,8 +10,8 @@ export class RemoveSoldAuctionsSettings extends SettingsEntry {
   static id = 'remove-sold-auctions';
   constructor() {
     super('remove-sold-auctions', 'Remove sold auctions automatically', null);
-    this.addSetting('Interval in seconds', 'interval', 60);
-    this.addSetting('IFTTT Key', 'ifttt-key', '');
+    this.addSetting('Interval in seconds', 'interval', 60, 'number');
+    this.addSetting('IFTTT Key', 'ifttt-key', '', 'text');
   }
 }
 

--- a/app/transferlist/transer-totals.js
+++ b/app/transferlist/transer-totals.js
@@ -10,7 +10,7 @@ export class TransferTotalsSettings extends SettingsEntry {
   constructor() {
     super('transfer-totals', 'Transfer list totals', null);
 
-    this.addSetting('Show transfer list totals', 'show-transfer-totals', 'true');
+    this.addSetting('Show transfer list totals', 'show-transfer-totals', true, 'checkbox');
   }
 }
 


### PR DESCRIPTION
I extended the settings API and introduced input types `number`, `checkbox` and `text` to render appropriate input  fields in the settings area.
Checkbox values are backwards compatible through a simple `.toString()` cast.
Since there are no unit tests I can rely on, it would be good if someone could double check if all features still work as expected.
As far as I can tell my existing personal settings are still working.