### PR TITLE
added 5% ea tax

### DIFF
--- a/app/futbin/futbin-prices.js
+++ b/app/futbin/futbin-prices.js
@@ -354,8 +354,11 @@ export class FutbinPrices extends BaseScript {
     }
 
     if (showBargain) {
+      // Add 5% EA Tax to price before comparing
+      var binPriceFivePercent = (5 / 100) * item.item._auction.buyNowPrice;
+      var binPrice = item.item._auction.buyNowPrice + binPriceFivePercent;
       if (item.item._auction &&
-        item.item._auction.buyNowPrice < futbinData[playerId].prices[platform].LCPrice.toString().replace(/[,.]/g, '')) {
+        binPrice < futbinData[playerId].prices[platform].LCPrice.toString().replace(/[,.]/g, '')) {
         target.addClass('futbin-bargain');
       }
     }


### PR DESCRIPTION
From the enhancement I created:

https://github.com/Mardaneus86/futwebapp-tampermonkey/issues/207

I managed to add 5% to the BIN price before comparing.  I feel this allows the price to correctly identify to contain at least a profit after tax.

Let me know if you can see any issues.